### PR TITLE
Remove unnecessary closures

### DIFF
--- a/woori-db/src/actors/state.rs
+++ b/woori-db/src/actors/state.rs
@@ -21,7 +21,7 @@ impl Handler<State> for Executor {
         if fractions[0].eq("INSERT") {
             let state = fractions
                 .last()
-                .ok_or_else(|| Error::FailedToParseState)?
+                .ok_or(Error::FailedToParseState)?
                 .to_owned();
             let state = &state[..(state.len() - 1)];
 
@@ -36,7 +36,7 @@ impl Handler<State> for Executor {
         {
             let state = fractions
                 .get(fractions.len() - 2)
-                .ok_or_else(|| Error::FailedToParseState)?
+                .ok_or(Error::FailedToParseState)?
                 .to_owned();
 
             let resp: Result<HashMap<String, Types>, Error> = match from_str(state) {
@@ -71,7 +71,7 @@ impl Handler<PreviousRegistry> for Executor {
         {
             let state = fractions
                 .last()
-                .ok_or_else(|| Error::FailedToParseRegistry)?
+                .ok_or(Error::FailedToParseRegistry)?
                 .to_owned();
             let state = &state[..(state.len() - 1)];
 

--- a/woori-db/src/actors/when.rs
+++ b/woori-db/src/actors/when.rs
@@ -54,7 +54,7 @@ impl Handler<ReadEntityRange> for Executor {
             {
                 let state = fractions
                     .last()
-                    .ok_or_else(|| Error::FailedToParseState)?
+                    .ok_or(Error::FailedToParseState)?
                     .to_owned();
                 let date: Result<DateTime<Utc>, Error> = match from_str(fractions[1]) {
                     Ok(x) => Ok(x),
@@ -81,7 +81,7 @@ impl Handler<ReadEntityRange> for Executor {
             {
                 let state = fractions
                     .get(fractions.len() - 2)
-                    .ok_or_else(|| Error::FailedToParseState)?
+                    .ok_or(Error::FailedToParseState)?
                     .to_owned();
                 let date: Result<DateTime<Utc>, Error> = match from_str(fractions[1]) {
                     Ok(x) => Ok(x),
@@ -141,7 +141,7 @@ impl Handler<ReadEntitiesAt> for Executor {
             if fractions[0].eq("INSERT") && fractions[3].eq(&msg.entity_name) {
                 let state = fractions
                     .last()
-                    .ok_or_else(|| Error::FailedToParseState)?
+                    .ok_or(Error::FailedToParseState)?
                     .to_owned();
 
                 let resp: Result<HashMap<String, Types>, Error> = match from_str(state) {
@@ -160,7 +160,7 @@ impl Handler<ReadEntitiesAt> for Executor {
             {
                 let state = fractions
                     .get(fractions.len() - 2)
-                    .ok_or_else(|| Error::FailedToParseState)?
+                    .ok_or(Error::FailedToParseState)?
                     .to_owned();
 
                 let resp: Result<HashMap<String, Types>, Error> = match from_str(state) {
@@ -219,7 +219,7 @@ impl Handler<ReadEntityIdAt> for Executor {
             {
                 let state = fractions
                     .last()
-                    .ok_or_else(|| Error::FailedToParseState)?
+                    .ok_or(Error::FailedToParseState)?
                     .to_owned();
 
                 let resp: Result<HashMap<String, Types>, Error> = match from_str(state) {
@@ -239,7 +239,7 @@ impl Handler<ReadEntityIdAt> for Executor {
             {
                 let state = fractions
                     .get(fractions.len() - 2)
-                    .ok_or_else(|| Error::FailedToParseState)?
+                    .ok_or(Error::FailedToParseState)?
                     .to_owned();
 
                 let resp: Result<HashMap<String, Types>, Error> = match from_str(state) {

--- a/woori-db/src/auth/io.rs
+++ b/woori-db/src/auth/io.rs
@@ -60,7 +60,7 @@ pub async fn find_user(user: schemas::User) -> Result<UserRegistry, Error> {
     let user_content = buffer
         .lines()
         .find(|l| (l.as_ref().unwrap_or(&String::new())).contains(&uuid.to_string()))
-        .ok_or_else(|| Error::Unknown)??;
+        .ok_or(Error::Unknown)??;
 
     let user: Result<UserRegistry, Error> = match from_str(&user_content) {
         Ok(u) => Ok(u),

--- a/woori-db/src/controllers/clauses.rs
+++ b/woori-db/src/controllers/clauses.rs
@@ -60,7 +60,7 @@ async fn filter_where_clauses(
                             }
                         }
                         Clause::SimpleComparisonFunction(f, key, value) => {
-                            let key = args_to_key.get(key).unwrap_or_else(|| &default);
+                            let key = args_to_key.get(key).unwrap_or(&default);
                             if let Some(v) = state.get(key) {
                                 match f {
                                     wql::Function::Eq => v == value,
@@ -93,7 +93,7 @@ async fn filter_where_clauses(
                             }
                         }
                         Clause::ComplexComparisonFunctions(wql::Function::In, key, set) => {
-                            let key = args_to_key.get(key).unwrap_or_else(|| &default);
+                            let key = args_to_key.get(key).unwrap_or(&default);
                             if let Some(v) = state.get(key) {
                                 set.contains(v)
                             } else {
@@ -105,7 +105,7 @@ async fn filter_where_clauses(
                             key,
                             start_end,
                         ) => {
-                            let key = args_to_key.get(key).unwrap_or_else(|| &default);
+                            let key = args_to_key.get(key).unwrap_or(&default);
                             if let Some(v) = state.get(key) {
                                 v >= &start_end[0] && v <= &start_end[1]
                             } else {
@@ -171,7 +171,7 @@ fn or_clauses(
                 }
             }
             Clause::ComplexComparisonFunctions(wql::Function::In, key, set) => {
-                let key = args_to_key.get(key).unwrap_or_else(|| &default);
+                let key = args_to_key.get(key).unwrap_or(&default);
                 if let Some(v) = state.get(key) {
                     set.contains(v)
                 } else {
@@ -179,7 +179,7 @@ fn or_clauses(
                 }
             }
             Clause::ComplexComparisonFunctions(wql::Function::Between, key, start_end) => {
-                let key = args_to_key.get(key).unwrap_or_else(|| &default);
+                let key = args_to_key.get(key).unwrap_or(&default);
                 if let Some(v) = state.get(key) {
                     v >= &start_end[0] && v <= &start_end[1]
                 } else {


### PR DESCRIPTION
Hey there, Naomi, and congrats on the great project!

This PR consists in removing a few unnecessary closures used in `unwrap_or_else`s and `ok_or_else`s. I understand that these are usually more performant, but  there'd be no performance loss to switch to `*_or` on the ones I changed, since the values in the closures are already computed, slightly reducing code complexity at no runtime cost


[Relevant Clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations)
