### PR TITLE
proof of concept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 test_read = []
 history = []
 json = ["serde_json"]
+json_pure = ["json", "wql/json_pure"]
 
 [[bin]]
 name = "wooridb"

--- a/woori-db/Cargo.toml
+++ b/woori-db/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 test_read = []
 history = []
 json = ["serde_json"]
+json_pure = ["json", "wql/json_pure"]
 
 [dependencies]
 actix = "0.10.0"

--- a/woori-db/src/controllers/query.rs
+++ b/woori-db/src/controllers/query.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use actix_web::{HttpResponse, Responder};
+use log::debug;
 use rayon::prelude::*;
 use uuid::Uuid;
 use wql::{ToSelect, Types, Wql};
@@ -46,6 +47,7 @@ pub async fn wql_handler(
             select_keys_with_id(entity, uuid, keys, local_data).await
         }
         Ok(Wql::Select(entity, ToSelect::All, None, functions)) => {
+            debug! ("wql_handler will call select_all");
             select_all(entity, local_data, functions).await
         }
         Ok(Wql::Select(entity, ToSelect::Keys(keys), None, functions)) => {
@@ -456,6 +458,7 @@ pub async fn select_all(
             return Err(Error::EntityNotCreated(entity));
         }
         .to_owned();
+        debug! ("select_all returning registries: {:?}", registries);
         registries
     };
 

--- a/woori-db/src/main.rs
+++ b/woori-db/src/main.rs
@@ -18,7 +18,7 @@ use http::{ping, readiness, routes};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    std::env::set_var("RUST_LOG", "actix_web=info");
+    //std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
     let env_port = std::env::var("PORT").unwrap_or_else(|_| "1438".to_owned());
     let port = env_port.parse::<u16>().expect("PORT must be a u16");

--- a/woori-db/src/schemas/query.rs
+++ b/woori-db/src/schemas/query.rs
@@ -2,9 +2,12 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::{core::pretty_config_output, model::error::Error};
 use chrono::{DateTime, Utc};
+use log::debug;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use wql::Types;
+#[cfg(feature = "json_pure")]
+use wql::TypesSelfDescribing;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CountResponse {
@@ -19,6 +22,9 @@ pub struct CountId {
 }
 #[derive(Serialize)]
 pub struct CountAll {
+    #[cfg(feature = "json_pure")]
+    response: BTreeMap<Uuid, HashMap<String, TypesSelfDescribing>>,
+    #[cfg(not(feature = "json_pure"))]
     response: BTreeMap<Uuid, HashMap<String, Types>>,
     count: usize,
 }
@@ -49,6 +55,9 @@ pub struct CountOptionGroupBy {
 }
 #[derive(Serialize)]
 pub struct CountOptionSelect {
+    #[cfg(feature = "json_pure")]
+    response: BTreeMap<Uuid, Option<HashMap<String, TypesSelfDescribing>>>,
+    #[cfg(not(feature = "json_pure"))]
     response: BTreeMap<Uuid, Option<HashMap<String, Types>>>,
     count: usize,
 }
@@ -162,6 +171,7 @@ impl CountResponse {
                     count,
                     response: state.to_owned(),
                 };
+                debug! ("Called Response::OptionSelect");
                 #[cfg(feature = "json")]
                 return Ok(serde_json::to_string(&resp)?);
 
@@ -202,6 +212,28 @@ impl CountResponse {
     }
 }
 
+#[cfg(feature = "json_pure")]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum Response {
+    Id(HashMap<String, Types>),
+    Intersect(HashMap<String, Types>),
+    Difference(HashMap<String, Types>),
+    Union(HashMap<String, Types>),
+    All(BTreeMap<Uuid, HashMap<String, TypesSelfDescribing>>),
+    Order(Vec<(Uuid, HashMap<String, Types>)>),
+    GroupBy(HashMap<String, BTreeMap<Uuid, HashMap<String, Types>>>),
+    OrderedGroupBy(HashMap<String, Vec<(Uuid, HashMap<String, Types>)>>),
+    OptionOrder(Vec<(Uuid, Option<HashMap<String, Types>>)>),
+    OptionGroupBy(HashMap<String, BTreeMap<Uuid, Option<HashMap<String, Types>>>>),
+    OptionSelect(BTreeMap<Uuid, Option<HashMap<String, TypesSelfDescribing>>>),
+    CheckValues(HashMap<String, bool>),
+    TimeRange(BTreeMap<DateTime<Utc>, HashMap<String, Types>>),
+    WithCount(CountResponse),
+    DateSelect(HashMap<String, HashMap<String, Types>>),
+    Join(Vec<HashMap<String, TypesSelfDescribing>>),
+}
+
+#[cfg(not(feature = "json_pure"))]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum Response {
     Id(HashMap<String, Types>),
@@ -233,7 +265,27 @@ impl From<HashMap<String, HashMap<String, Types>>> for Response {
         Self::DateSelect(map)
     }
 }
+#[cfg(feature = "json_pure")]
+impl From<BTreeMap<Uuid, Option<HashMap<String, Types>>>> for Response {
+    fn from(map: BTreeMap<Uuid, Option<HashMap<String, Types>>>) -> Self {
+        debug! ("Called from");
+        Self::OptionSelect (map.into_iter ()
+            .map (|(bk, bv)| {
+                if let Some (h) = bv {
+                    (bk, Some (h.into_iter().map(|(k, v)| (k, TypesSelfDescribing::from (v)) ).collect::<HashMap<String,TypesSelfDescribing>> ()))
+                }
+                else
+                {
+                    (bk, None)
+                }
+            }).collect ())
+    }
+}
 
+#[cfg(feature = "json_pure")]
+
+
+#[cfg(not(feature = "json_pure"))]
 impl From<BTreeMap<Uuid, Option<HashMap<String, Types>>>> for Response {
     fn from(map: BTreeMap<Uuid, Option<HashMap<String, Types>>>) -> Self {
         Self::OptionSelect(map)
@@ -258,6 +310,17 @@ impl From<BTreeMap<DateTime<Utc>, HashMap<String, Types>>> for Response {
     }
 }
 
+#[cfg(feature = "json_pure")]
+impl From<BTreeMap<Uuid, HashMap<String, Types>>> for Response {
+    fn from(map: BTreeMap<Uuid, HashMap<String, Types>>) -> Self {
+        Self::All(map.into_iter ()
+            .map (|(bk, bv)| {
+                (bk, bv.into_iter().map(|(k, v)| (k, TypesSelfDescribing::from (v)) ).collect::<HashMap<String,TypesSelfDescribing>> ())
+            }).collect ())
+    }
+}
+
+#[cfg(not(feature = "json_pure"))]
 impl From<BTreeMap<Uuid, HashMap<String, Types>>> for Response {
     fn from(map: BTreeMap<Uuid, HashMap<String, Types>>) -> Self {
         Self::All(map)
@@ -294,6 +357,253 @@ impl From<HashMap<String, BTreeMap<Uuid, Option<HashMap<String, Types>>>>> for R
     }
 }
 
+#[cfg(feature = "json_pure")]
+impl Response {
+    pub fn parse(
+        self,
+        key: String,
+        ent_b: &(String, String),
+        vec: &mut Vec<HashMap<String, TypesSelfDescribing>>,
+        b_hash: HashMap<TypesSelfDescribing, Vec<HashMap<String, TypesSelfDescribing>>>,
+    ) -> bool {
+        /*
+        let b_hash_sd: HashMap<TypesSelfDescribing, Vec<HashMap<String, TypesSelfDescribing>>> = b_hash.into_iter ().map (|(bk, bv)| {
+            (
+                TypesSelfDescribing::from (bk),
+                bv.into_iter ().map (|e| {
+                    e.into_iter ().map (|(k,v)| { ( k, TypesSelfDescribing::from (v) ) }).collect ()
+                }).collect ()
+            )
+        }).collect ();
+        */
+        match self {
+            Response::OptionGroupBy(_)
+            | Response::CheckValues(_)
+            | Response::TimeRange(_)
+            | Response::WithCount(_)
+            | Response::Id(_)
+            | Response::Intersect(_)
+            | Response::Difference(_)
+            | Response::Union(_)
+            | Response::GroupBy(_)
+            | Response::OrderedGroupBy(_)
+            | Response::Join(_)
+            | Response::DateSelect(_) => {
+                return false;
+            }
+            Response::All(state) => {
+                state.into_iter().for_each(|(_, s)| {
+                    let s_sd = s.into_iter ().map (|(k,v)| { (k, TypesSelfDescribing::from (v) ) }).collect::<HashMap<String, TypesSelfDescribing>> ();
+                    let type_key = s_sd.get(&key).unwrap_or(&TypesSelfDescribing::Nil);
+                    let entities = b_hash.get(type_key);
+                    if let Some(v) = entities {
+                        for ent in v {
+                            let mut s = s_sd.clone();
+                            for entry in ent
+                                .iter()
+                                .filter(|(k, _)| *k != "tx_time" && *k != &ent_b.1)
+                            {
+                                let entry_name = if s.contains_key(entry.0) {
+                                    format!("{}:{}", entry.0, ent_b.0)
+                                } else {
+                                    entry.0.to_owned()
+                                };
+                                s.insert(entry_name, entry.1.to_owned());
+                            }
+                            vec.push(s.to_owned());
+                        }
+                    }
+                });
+            }
+            Response::Order(state) => {
+                state.into_iter().for_each(|(_, s)| {
+                    let s_sd = s.into_iter ().map (|(k,v)| { (k, TypesSelfDescribing::from (v) ) }).collect::<HashMap<String, TypesSelfDescribing>> ();
+                    let type_key = s_sd.get(&key).unwrap_or(&TypesSelfDescribing::Nil);
+                    let entities = b_hash.get(type_key);
+                    if let Some(v) = entities {
+                        for ent in v {
+                            let mut s = s_sd.clone();
+                            for entry in ent
+                                .iter()
+                                .filter(|(k, _)| *k != "tx_time" && *k != &ent_b.1)
+                            {
+                                let entry_name = if s.contains_key(entry.0) {
+                                    format!("{}:{}", entry.0, ent_b.0)
+                                } else {
+                                    entry.0.to_owned()
+                                };
+                                s.insert(entry_name, entry.1.to_owned());
+                            }
+                            vec.push(s.to_owned());
+                        }
+                    }
+                });
+            }
+            Response::OptionOrder(state) => {
+                state.into_iter().for_each(|(_, s)| {
+                    if let Some(s) = s {
+                        let s_sd = s.into_iter ().map (|(k,v)| { (k, TypesSelfDescribing::from (v) ) }).collect::<HashMap<String, TypesSelfDescribing>> ();
+                        let type_key = s_sd.get(&key).unwrap_or(&TypesSelfDescribing::Nil);
+                        let entities = b_hash.get(type_key);
+                        if let Some(v) = entities {
+                            for ent in v {
+                                let mut s = s_sd.clone();
+                                for entry in ent
+                                    .iter()
+                                    .filter(|(k, _)| *k != "tx_time" && *k != &ent_b.1)
+                                {
+                                    let entry_name = if s.contains_key(entry.0) {
+                                        format!("{}:{}", entry.0, ent_b.0)
+                                    } else {
+                                        entry.0.to_owned()
+                                    };
+                                    s.insert(entry_name, entry.1.to_owned());
+                                }
+                                vec.push(s.to_owned());
+                            }
+                        }
+                    }
+                });
+            }
+            Response::OptionSelect(state) => {
+                state.into_iter().for_each(|(_, s)| {
+                    if let Some(s) = s {
+                        let type_key = s.get(&key).unwrap_or(&TypesSelfDescribing::Nil);
+                        let entities = b_hash.get(type_key);
+                        if let Some(v) = entities {
+                            for ent in v {
+                                let mut s = s.clone();
+                                for entry in ent
+                                    .iter()
+                                    .filter(|(k, _)| *k != "tx_time" && *k != &ent_b.1)
+                                {
+                                    let entry_name = if s.contains_key(entry.0) {
+                                        entry.0.to_owned()
+                                    } else {
+                                        format!("{}:{}", entry.0, ent_b.0)
+                                    };
+                                    s.insert(entry_name, entry.1.to_owned());
+                                }
+                                vec.push(s.to_owned());
+                            }
+                        }
+                    }
+                });
+            }
+        }
+        true
+    }
+
+    pub fn hash(self, key: &str) -> Option<HashMap<TypesSelfDescribing, Vec<HashMap<String, TypesSelfDescribing>>>> {
+        let mut hm = HashMap::new();
+        match self {
+            Response::All(state) => {
+                state.into_iter().for_each(|(_, s)| {
+                    let s_sd = s.into_iter ().map (|(k,v)| { (k, TypesSelfDescribing::from (v) ) }).collect::<HashMap<String, TypesSelfDescribing>> ();
+                    let entry = hm
+                        .entry(s_sd.get(key).unwrap_or(&TypesSelfDescribing::Nil).to_owned())
+                        .or_insert(Vec::new());
+                    (*entry).push(s_sd);
+                });
+            }
+            Response::Order(state) => {
+                state.into_iter().for_each(|(_, s)| {
+                    let s_sd = s.into_iter ().map (|(k,v)| { (k, TypesSelfDescribing::from (v) ) }).collect::<HashMap<String, TypesSelfDescribing>> ();
+                    let entry = hm
+                        .entry(s_sd.get(key).unwrap_or(&TypesSelfDescribing::Nil).to_owned())
+                        .or_insert(Vec::new());
+                    (*entry).push(s_sd);
+                });
+            }
+            Response::OptionOrder(state) => {
+                state.into_iter().for_each(|(_, so)| {
+                    if let Some(s) = so {
+                        let s_sd = s.into_iter ().map (|(k,v)| { (k, TypesSelfDescribing::from (v) ) }).collect::<HashMap<String, TypesSelfDescribing>> ();
+                        let entry = hm
+                            .entry(s_sd.get(key).unwrap_or(&TypesSelfDescribing::Nil).to_owned())
+                            .or_insert(Vec::new());
+                        (*entry).push(s_sd);
+                    }
+                });
+            }
+            Response::OptionSelect(state) => {
+                state.into_iter().for_each(|(_, s)| {
+                    if let Some(s) = s {
+                        let entry = hm
+                            .entry(s.get(key).unwrap_or(&TypesSelfDescribing::Nil).to_owned())
+                            .or_insert(Vec::new());
+                        (*entry).push(s);
+                    }
+                });
+            }
+            Response::OptionGroupBy(_)
+            | Response::CheckValues(_)
+            | Response::Join(_)
+            | Response::TimeRange(_)
+            | Response::WithCount(_)
+            | Response::Id(_)
+            | Response::Intersect(_)
+            | Response::Difference(_)
+            | Response::Union(_)
+            | Response::GroupBy(_)
+            | Response::OrderedGroupBy(_)
+            | Response::DateSelect(_) => {
+                return None;
+            }
+        }
+
+        Some(hm)
+    }
+
+    pub fn to_string(&self) -> Result<String, Error> {
+        match self {
+            Response::Id(state) => Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?),
+            Response::Intersect(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::Difference(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::Union(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::CheckValues(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::TimeRange(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::All(state) => { debug! ("Called Response.to_string for Response::All"); Ok(serde_json::to_string (&state)?) },
+            Response::Order(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::GroupBy(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::OrderedGroupBy(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::OptionOrder(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::OptionGroupBy(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::WithCount(state) => state.to_response(),
+            Response::OptionSelect(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::DateSelect(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+            Response::Join(state) => {
+                Ok(ron::ser::to_string_pretty(&state, pretty_config_output())?)
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "json_pure"))]
 impl Response {
     pub fn parse(
         self,

--- a/wql/Cargo.toml
+++ b/wql/Cargo.toml
@@ -11,6 +11,8 @@ license = "LGPL-3.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+json_pure = []
 
 [dependencies]
 uuid = { version = "0.8", features = ["serde", "v4"] }


### PR DESCRIPTION
pure json response

So this is not for merging, just a proof of concept. It's only implemented for SELECT * right now. Bincode doesn't support tagged enums. The Types enum needed to be mirrored to allow separate serde annotations for transfer vs internal serialisation (See https://github.com/serde-rs/serde/issues/1310). There is probably some redundant stuff in my experiments to make Response support the new TypesSelfDescribed enum.

I tried (note that Internal tagging does not allow the enum variants with values):
#[serde(tag = "type", content = "value")]
pub enum TypesSelfDescribing {

"tx_time":{"type":"DateTime","value":"2022-08-21T12:06:35.595025264Z"},
"last_name":{"type":"String","value":"Rabbit"}

#[serde(untagged)]
pub enum TypesSelfDescribing {

"tx_time":"2022-08-21T12:06:35.595025264Z",
"last_name":"Rabbit"

//with no serde annotation:
pub enum TypesSelfDescribing {
"tx_time":{"DateTime":"2022-08-21T12:06:35.595025264Z"},
"last_name":{"String":"Rabbit"}

So for that last format I guess no tag means that bincode would be ok and therefore no mirroring, but I guess the its no longer possible to round trip. Maybe all that was needed was to replace:

https://github.com/naomijub/wooridb/blob/646997e36dee18e54614271b9829e695de704888/woori-db/src/schemas/query.rs#L496

with the serde_json::from_str